### PR TITLE
Use newer Github header for the sha2 hash

### DIFF
--- a/src/Security/SignatureValidator.php
+++ b/src/Security/SignatureValidator.php
@@ -26,7 +26,7 @@ class SignatureValidator implements SignatureValidatorInterface
      */
     public function validate(RequestInterface $request, $secret)
     {
-        $signature   = $request->getHeader('X-Hub-Signature');
+        $signature   = $request->getHeader('X-Hub-Signature-256');
         $requestBody = $request->getBody();
         $requestBody->rewind();
 

--- a/tests/Security/SignatureValidatorTest.php
+++ b/tests/Security/SignatureValidatorTest.php
@@ -111,7 +111,7 @@ class SignatureValidatorTest extends \PHPUnit_Framework_TestCase
         $stream->write($requestContent);
 
         return (new ServerRequest())
-            ->withAddedHeader('X-Hub-Signature', $requestSignatureHeader)
+            ->withAddedHeader('X-Hub-Signature-256', $requestSignatureHeader)
             ->withBody($stream);
     }
 


### PR DESCRIPTION
A simple update to use newer Github header `X-Hub-Signature-256` to use the sha2 hash. The security tests are already using the sha256 algorithm.

This is the Github documentation for reference
https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-object-common-properties
![image](https://user-images.githubusercontent.com/253405/96207668-bd650980-0f39-11eb-9c13-e3cddf0f7989.png)
