### PR TITLE
Using the autoload-dev setting on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Swop\\GitHubWebHook\\": "src/",
+            "Swop\\GitHubWebHook\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Swop\\GitHubWebHook\\Tests\\": "tests/"
         }
     },


### PR DESCRIPTION
# Changed log

- In the `composer.json` file, the `"Swop\\GitHubWebHook\\Tests\\": "tests/"` should be on `autoload-dev` setting.